### PR TITLE
Add note about tome tests requiring a virtual environment to pass

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,9 @@ pre-commit run --all-files
 
 ## Running the Tests
 
+It is mandatory to **use a virtual environment** to ensure that all tests will be able to
+run without any restriction. Otherwise, some tests may fail.
+
 **tome** uses `pytest` for its test suite. Ensure you have `pytest` installed:
 
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@
 
 If you wish to contribute or modify **tome**, follow these steps to clone the repository
 and install it in editable mode with all the required development dependencies. It is
-recommended to **create a virtual environment** to ensure that your project dependencies
-are isolated.
+mandatory to **create a virtual environment** to ensure that all tests will be able to
+run without any restriction.
 
 ```
 git clone https://github.com/jfrog/tome.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@
 
 If you wish to contribute or modify **tome**, follow these steps to clone the repository
 and install it in editable mode with all the required development dependencies. It is
-mandatory to **create a virtual environment** to ensure that all tests will be able to
-run without any restriction.
+recommended to **create a virtual environment** to ensure that your project dependencies
+are isolated.
 
 ```
 git clone https://github.com/jfrog/tome.git


### PR DESCRIPTION
The original contribution guide only recomends using virtual environment, but when running pytest, a few tests fail due missing virtual environment:

```
tests/integration/test_requirements.py FFF..                                                                                                                                                                                                  [ 51%]

....

 def test_install_editable_with_requirements_fail():
        c = TestClient()
        c.run("new mynamespace:mycommand")
        c.save({"requirements.txt": "tomato_this_wont_exist"})
        c.run("install . -e -v", assert_error=True)
        # TODO: Decide if better to remove these commands, disable or what
>       assert "ERROR: No matching distribution found for tomato_this_wont_exist" in c.out
E       AssertionError: assert 'ERROR: No matching distribution found for tomato_this_wont_exist' in 'Error: You must be within a virtual environment to install requirements or use \nthe --create-env argument.\n'
E        +  where 'Error: You must be within a virtual environment to install requirements or use \nthe --create-env argument.\n' = <tests.utils.tools.TestClient object at 0x1077af790>.out


```

This PR changes from a suggestion to mandatory the virtual environment need. 