### PR TITLE
[UX] Provide better error when using bad install

### DIFF
--- a/tests/integration/test_install.py
+++ b/tests/integration/test_install.py
@@ -2,7 +2,6 @@ import os
 import shutil
 import sys
 import textwrap
-import re
 
 import pytest
 import responses
@@ -466,5 +465,4 @@ def test_install_script_file():
     client = TestClient()
     dummy_script = temp_file(suffix='.py', prefix='cmd_foobar')
     client.run(f"install -e '{dummy_script}'", assert_error=True)
-    # INFO: It may contain breaking lines
-    assert re.search(r"Error: The directory '.*' does not exist or is not a directory", client.out, re.DOTALL)
+    assert "Error: The following directory does not exist or is not a directory: " in client.out

--- a/tests/integration/test_install.py
+++ b/tests/integration/test_install.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import sys
 import textwrap
+import re
 
 import pytest
 import responses
@@ -10,7 +11,7 @@ from tome.internal.utils.files import rmdir
 
 from tests.utils.tools import TestClient
 from tests.utils.tools import zipdir
-from tests.utils.files import temp_folder
+from tests.utils.files import temp_folder, temp_file
 
 
 def _create_zip(folder, zippath=None):
@@ -459,3 +460,11 @@ def test_validate_git_install():
     install_source = f"{os.path.join(client.current_folder, git_repo_folder)}/.git"
     client.run(f"install '{install_source}'", assert_error=True)
     assert "No valid tome commands were found in the cloned repository" in client.out
+
+
+def test_install_script_file():
+    client = TestClient()
+    dummy_script = temp_file(suffix='.py', prefix='cmd_foobar')
+    client.run(f"install -e '{dummy_script}'", assert_error=True)
+    # INFO: It may contain breaking lines
+    assert re.search(r"Error: The directory '.*' does not exist or is not a directory", client.out, re.DOTALL)

--- a/tests/integration/test_install.py
+++ b/tests/integration/test_install.py
@@ -465,4 +465,4 @@ def test_install_script_file():
     client = TestClient()
     dummy_script = temp_file(suffix='.py', prefix='cmd_foobar')
     client.run(f"install -e '{dummy_script}'", assert_error=True)
-    assert "Error: The following directory does not exist or is not a directory: " in client.out
+    assert "Error: The following path does not exist or is not a directory: " in client.out

--- a/tests/integration/test_install.py
+++ b/tests/integration/test_install.py
@@ -462,6 +462,9 @@ def test_validate_git_install():
 
 
 def test_install_script_file():
+    """
+    Test that the install command fails when a script file is provided instead of a directory.
+    """
     client = TestClient()
     dummy_script = temp_file(suffix='.py', prefix='cmd_foobar')
     client.run(f"install -e '{dummy_script}'", assert_error=True)

--- a/tests/integration/test_uninstall.py
+++ b/tests/integration/test_uninstall.py
@@ -1,7 +1,6 @@
-import os
-import textwrap
-
 from tests.utils.tools import TestClient
+from tests.utils.files import temp_file
+
 
 
 def test_install_empty_argument():
@@ -19,3 +18,13 @@ def test_uninstall_with_command_name():
     client.run("install .")
     client.run("uninstall namespace:mycommand", assert_error=True)
     assert "You are trying to uninstall a command 'namespace:mycommand'" in client.out
+
+
+def test_uninstall_script_file():
+    """
+    Test that the uninstall command fails when a script file is provided instead of a directory.
+    """
+    client = TestClient()
+    dummy_script = temp_file(suffix='.py', prefix='cmd_foobar')
+    client.run(f"uninstall '{dummy_script}'", assert_error=True)
+    assert "Error: The following path does not exist or is not a directory: " in client.out

--- a/tests/utils/files.py
+++ b/tests/utils/files.py
@@ -45,3 +45,10 @@ def temp_folder(create_dir=True):
     if create_dir:
         os.makedirs(nt)
     return nt
+
+
+def temp_file(suffix='', prefix='tmp'):
+    folder_path = temp_folder()
+    fd, name = tempfile.mkstemp(suffix=suffix, prefix=prefix, dir=folder_path)
+    os.close(fd)
+    return name

--- a/tome/internal/installer.py
+++ b/tome/internal/installer.py
@@ -342,5 +342,7 @@ def uninstall_from_source(source, cache_base_folder, cache_remove_folder):
             raise TomeException("Attempted to uninstall the entire cache base folder, operation cancelled.")
         rmdir(cache_remove_folder)
         return source
+    elif os.path.isfile(source.uri):
+        raise TomeException(f"The following path does not exist or is not a directory: '{source}'. Please, provide a valid directory.")
     else:
         raise TomeException(f"Source '{source}' is not installed or already uninstalled.")

--- a/tome/internal/installer.py
+++ b/tome/internal/installer.py
@@ -164,7 +164,7 @@ def _has_valid_commands(directory):
     that appear to contain valid tome commands.
     """
     if not os.path.isdir(directory):
-        raise TomeException(f"The directory '{directory}' does not exist or is not a directory. Please, provide a valid directory.")
+        raise TomeException(f"The following directory does not exist or is not a directory: '{directory}'. Please, provide a valid directory.")
     # List only the first-level subdirectories of 'directory'
     for subdir_name in os.listdir(directory):
         subdir = os.path.join(directory, subdir_name)

--- a/tome/internal/installer.py
+++ b/tome/internal/installer.py
@@ -163,6 +163,8 @@ def _has_valid_commands(directory):
     Check the first-level subdirectories of the given directory to find files
     that appear to contain valid tome commands.
     """
+    if not os.path.isdir(directory):
+        raise TomeException(f"The directory '{directory}' does not exist or is not a directory. Please, provide a valid directory.")
     # List only the first-level subdirectories of 'directory'
     for subdir_name in os.listdir(directory):
         subdir = os.path.join(directory, subdir_name)

--- a/tome/internal/installer.py
+++ b/tome/internal/installer.py
@@ -164,7 +164,7 @@ def _has_valid_commands(directory):
     that appear to contain valid tome commands.
     """
     if not os.path.isdir(directory):
-        raise TomeException(f"The following directory does not exist or is not a directory: '{directory}'. Please, provide a valid directory.")
+        raise TomeException(f"The following path does not exist or is not a directory: '{directory}'. Please, provide a valid directory.")
     # List only the first-level subdirectories of 'directory'
     for subdir_name in os.listdir(directory):
         subdir = os.path.join(directory, subdir_name)


### PR DESCRIPTION
When installing a script using `tome install -e` but instead of pointing to the folder where those scripts are, when pointing to a specific script, the command fails with an not expected scenario:

```txt
tome install -e ~/Development/tome/tome-commands/ansible/list_inventories.py
Error: Traceback (most recent call last):
  File "/home/uilian/Development/tome/tomescripts/tome/cli.py", line 405, in main
    cli.run(args)
  File "/home/uilian/Development/tome/tomescripts/tome/cli.py", line 337, in run
    command.run(self._tome_api, args[0][1:])
  File "/home/uilian/Development/tome/tomescripts/tome/command.py", line 177, in run
    info = self._method(tome_api, self.parser, *args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/uilian/Development/tome/tomescripts/tome/commands/install.py", line 67, in install
    result = tome_api.install.install_editable(source, args.force_requirements, args.create_env)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/uilian/Development/tome/tomescripts/tome/api/subapi/install.py", line 15, in install_editable
    return install_editable(source, self.tome_api.cache_folder, force_requirements, create_env)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/uilian/Development/tome/tomescripts/tome/internal/installer.py", line 236, in install_editable
    if not _has_valid_commands(source.uri):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/uilian/Development/tome/tomescripts/tome/internal/installer.py", line 169, in _has_valid_commands
    for subdir_name in os.listdir(directory):
                       ^^^^^^^^^^^^^^^^^^^^^
NotADirectoryError: [Errno 20] Not a directory: '/home/uilian/Development/tome/tome-commands/ansible/list_inventories.py'
```

Using the following PR content, the output will be:

```
tome install -e ~/Development/tome/tome-commands/ansible/list_inventories.py

Error: The following directory does not exist or is not a directory: '/home/uilian/Development/tome/tome-commands/ansible/list_inventories.py'. Please, provide a valid directory.
```